### PR TITLE
bundle supporter hats in JarJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,14 @@ dependencies {
 
     compileOnly("mezz.jei:jei-${project.mc_version}-neoforge-api:${project.jei}")
     runtimeOnly("mezz.jei:jei-${project.mc_version}-neoforge:${project.jei}")
+
+    def galena_hats_version = "${mc_version}-${galena_hats}"
+    implementation(jarJar("dev.galena:hats-neoforge:$galena_hats_version") {
+        version {
+            strictly("[${galena_hats_version},)")
+            prefer(galena_hats_version)
+        }
+    })
 }
 
 subsystems {
@@ -60,9 +68,10 @@ subsystems {
 }
 
 repositories {
-    maven { url "https://maven.teamabnormals.com/" }
+    maven { url = "https://maven.teamabnormals.com/" }
     maven { url = "https://maven.blamejared.com/" }
     maven { url = "https://modmaven.dev" }
+    maven { url = "https://registry.somethingcatchy.net/repository/maven-public/" }
 }
 
 tasks.withType(ProcessResources).configureEach {
@@ -73,7 +82,9 @@ tasks.withType(ProcessResources).configureEach {
     }
 }
 
-tasks.named("jar", Jar).configure {
+tasks.jar {
+    archiveClassifier = "slim"
+
     manifest {
         attributes([
                 "Specification-Title"     : project.mod_name,
@@ -85,6 +96,10 @@ tasks.named("jar", Jar).configure {
                 "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }
+}
+
+tasks.jarJar {
+    archiveClassifier = ""
 }
 
 idea {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ blueprint=8.0.0
 jei=19.21.0.247
 clayworks=4.0.0
 gallery=2.0.0
+galena_hats=1.2.1


### PR DESCRIPTION
The archive classifiers stuff is to have the files named more sensible.
This way the
- `heart_crystals_version.jar` is the one with the hats bundled which should be uploaded
- `heart_crystals_version-slim.jar` is one without having it bundled (this would only be useful to upload to maven or something)